### PR TITLE
Fixed colors in Chrome menu.

### DIFF
--- a/gtk-2.0/styles/menu-menubar
+++ b/gtk-2.0/styles/menu-menubar
@@ -147,6 +147,10 @@ style "menubar-item"
   ythickness			= 1
 }
 
+style "chrome_menu"
+{
+        bg[NORMAL] = @text_color
+}
 
 style "chrome_menu_item"
 {
@@ -169,4 +173,5 @@ class "GtkTearoffMenuItem"		style "menuitem"
 class "GtkMenuBar*" 		     	style "menubar"
 widget_class "*<GtkMenuBar>*"		style "menubar"
 widget_class "*<GtkMenuBar>.<GtkMenuItem>*"	style "menubar-item"
+widget_class "*<GtkCustomMenu>*" style "chrome_menu"
 widget_class "*<GtkCustomMenu>*<GtkCustomMenuItem>*" style "chrome_menu_item"


### PR DESCRIPTION
Fixed colors in Chrome menu. This fixes #35, resolves #40 and closes #53.

Screenshot **before** applying fix:
![iris_before_bug_fixes](https://cloud.githubusercontent.com/assets/4950658/2751643/048a636c-c8df-11e3-82eb-b9213add4928.png)

Screenshot **after** applying fix:
![iris_after_bug_fixes](https://cloud.githubusercontent.com/assets/4950658/2751645/1ffb11c8-c8df-11e3-9449-6279ab9fdf70.png)
