### PR TITLE
Fixed problem with Java apps having white text on white menus

### DIFF
--- a/gtk-2.0/styles/menu-menubar
+++ b/gtk-2.0/styles/menu-menubar
@@ -3,6 +3,8 @@ style "menu"="default"
 xthickness=0
 ythickness=0
 
+  bg[NORMAL] = @text_color
+
   engine "pixmap"
   {
     image


### PR DESCRIPTION
Fixes issue #62.
As an unintended side effect, disabled menu items no longer have the light shadow/blur, _except_ in Java apps, where it's extra intense.

Netbeans:
![Netbeans with readable menus](https://cloud.githubusercontent.com/assets/4693844/3633912/d927b758-0f04-11e4-8db3-ac0285e4fbe8.png)

GIMP, showing how this change makes disabled menu items look:
![GIMP with some disabled menu items](https://cloud.githubusercontent.com/assets/4693844/3633911/d8d5f666-0f04-11e4-8019-52f3e80f59b1.png)
