### PR TITLE
Fixed Atom text editor having the wrong menubar background colour.

### DIFF
--- a/gtk-2.0/styles/menu-menubar
+++ b/gtk-2.0/styles/menu-menubar
@@ -85,6 +85,7 @@ style "tearoffmenuitem"	= "menuitem"
 style "menubar"		
 
 {
+	bg[NORMAL] = @text_color
     text[NORMAL] = @bg_color
 	text[PRELIGHT] = @bg_color
 	text[SELECTED] = @bg_color


### PR DESCRIPTION
Fixes #76 
Atom grabs the color from a gtk menu bar's bg[GTK_STATE_NORMAL] style property (see https://github.com/atom/atom-shell/commit/009e0790fe54f80be15f301336c8bdb251e0b927). Since Iris use an image for the background, Atom doesn't get the correct color. In Iris, setting the menubar's bg[NORMAL] color to the same color as the image has no effect on gtk apps (that I can tell), but means Atom gets the correct color for its menu.