### PR TITLE
Remove scrollbar steppers gtk

### DIFF
--- a/gtk-2.0/gtkrc
+++ b/gtk-2.0/gtkrc
@@ -92,8 +92,8 @@ style "default"
   GtkScrollbar::slider_width                    = 10
   #GtkScrollbar::stepper_size                    = 24
   GtkScrollbar::activate-slider                 = 1
-  #GtkScrollbar::has-backward-stepper            = 1
-  #GtkScrollbar::has-forward-stepper             = 1
+  GtkScrollbar::has-backward-stepper            = 0
+  GtkScrollbar::has-forward-stepper             = 0
   #GtkScrollbar::has-secondary-backward-stepper  = 0
   #GtkScrollbar::has-secondary-forward-stepper   = 0
 

--- a/gtk-3.0/gtk-widgets.css
+++ b/gtk-3.0/gtk-widgets.css
@@ -27,8 +27,8 @@
     -GtkRange-stepper-spacing: 0;
     -GtkRange-trough-border: 0;
     -GtkRange-trough-under-steppers: 1;
-    -GtkScrollbar-has-backward-stepper: false;
-    -GtkScrollbar-has-forward-stepper: false;
+    -GtkScrollbar-has-backward-stepper: 0;
+    -GtkScrollbar-has-forward-stepper: 0;
     -GtkScrolledWindow-scrollbar-spacing: 0;
     -GtkScrolledWindow-scrollbars-within-bevel: 1;
     -GtkStatusbar-shadow-type: none;


### PR DESCRIPTION
This removes the space used at the top and bottom of the scrollbar area intended for the scrollbar arrow buttons and allows the full utilization by the actual scrollbar.
